### PR TITLE
Prevent a crash when the find cursor is not defined.

### DIFF
--- a/lib/publication.js
+++ b/lib/publication.js
@@ -73,7 +73,8 @@ Publication.prototype._republish = function() {
 };
 
 Publication.prototype._getCursor = function() {
-    return this.options.find.apply(this.subscription.meteorSub, this.args);
+    find = this.options.find;
+    return find ? find.apply(this.subscription.meteorSub, this.args) : null;
 };
 
 Publication.prototype._getCollectionName = function() {


### PR DESCRIPTION
For some reason currently unknown to me, I am seeing numerous crashes occur in `Publication.prototype._getCursor` due the the find cursor becoming invalidated (typically on a restart of Meteor or when a user logs out). This fix makes the function return null instead of trying to call apply on an undefined value.