### PR TITLE
Make sure instance  options is not empty

### DIFF
--- a/lib/publish_composite.js
+++ b/lib/publish_composite.js
@@ -3,18 +3,20 @@ Meteor.publishComposite = function(name, options) {
         var subscription = new Subscription(this),
             instanceOptions = options,
             args = Array.prototype.slice.apply(arguments);
-
+        
         if (typeof instanceOptions === "function") {
             instanceOptions = instanceOptions.apply(this, args);
         }
-
-        var pub = new Publication(subscription, instanceOptions);
-        pub.publish();
-
-        this.onStop(function() {
-            pub.unpublish();
-        });
-
+        
+        if (!_.isEmpty(instanceOptions)) {
+            var pub = new Publication(subscription, instanceOptions);
+            pub.publish();
+    
+            this.onStop(function() {
+                pub.unpublish();
+            });
+        }
+        
         this.ready();
     });
 };


### PR DESCRIPTION
I have code that looks like this:

```js
Meteor.publishComposite('myCompositePublicationOfThings', function (id) {
  if (! this.userId) {
    return this.ready();
  }
  return {
    find: function () {
      return Things.find({ _id: id});
    },
    children: [{
      find: function (thing) {
        return OtherThings.find({ otherField: thing.otherField });
      }
    }]
  };
});
```

When the user logs in this works fine, I get the subscribed data, but the moment the user logs out, this error happens:

```
Exception from sub myCompositePublicationOfThings id eM9GDFPXtHQw9izEs TypeError: Cannot read property 'children' of undefined
I20150720-21:26:56.739(0)?     at new Publication (packages/reywood:publish-composite/lib/publication.js:5:1)
I20150720-21:26:56.740(0)?     at [object Object].<anonymous> (packages/reywood:publish-composite/lib/publish_composite.js:11:1)
I20150720-21:26:56.740(0)?     at packages/matb33:collection-hooks/collection-hooks.js:218:1
I20150720-21:26:56.741(0)?     at [object Object]._.extend.withValue (packages/meteor/dynamics_nodejs.js:56:1)
I20150720-21:26:56.741(0)?     at [object Object]._handler (packages/matb33:collection-hooks/collection-hooks.js:217:1)
I20150720-21:26:56.741(0)?     at maybeAuditArgumentChecks (packages/ddp/livedata_server.js:1617:1)
I20150720-21:26:56.742(0)?     at [object Object]._.extend._runHandler (packages/ddp/livedata_server.js:950:1)
I20150720-21:26:56.742(0)?     at [object Object]._.extend._startSubscription (packages/ddp/livedata_server.js:769:1)
I20150720-21:26:56.743(0)?     at [object Object]._.extend.protocol_handlers.sub (packages/ddp/livedata_server.js:582:1)
I20150720-21:26:56.743(0)?     at packages/ddp/livedata_server.js:546:1
```

This check makes sure that it doesn't happen.