### PR TITLE
Bind environment for observe/observeChanges callbacks

### DIFF
--- a/lib/publication.js
+++ b/lib/publication.js
@@ -20,8 +20,11 @@ class Publication {
 
         const collectionName = this._getCollectionName();
 
+        // Use Meteor.bindEnvironment to make sure the callbacks are run with the same
+        // environmentVariables as when publishing the "parent".
+        // It's only needed when publish is being recursively run.
         this.observeHandle = this.cursor.observe({
-            added: (doc) => {
+            added: Meteor.bindEnvironment((doc) => {
                 const alreadyPublished = this.publishedDocs.has(doc._id);
 
                 if (alreadyPublished) {
@@ -34,11 +37,11 @@ class Publication {
                     this.subscription.added(collectionName, doc);
                     this._publishChildrenOf(doc);
                 }
-            },
-            changed: (newDoc) => {
+            }),
+            changed: Meteor.bindEnvironment((newDoc) => {
                 debugLog('Publication.observeHandle.changed', `${collectionName}:${newDoc._id}`);
                 this._republishChildrenOf(newDoc);
-            },
+            }),
             removed: (doc) => {
                 debugLog('Publication.observeHandle.removed', `${collectionName}:${doc._id}`);
                 this._removeDoc(collectionName, doc._id);


### PR DESCRIPTION
This will preserve the environment variables so the child publications
also have `this.userId()` available, etc.

Fixes #102.