### PR TITLE
Upgraded Meteor package versions to 1.6.1

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,12 +1,12 @@
 Package.describe({
     name: 'reywood:publish-composite',
     summary: 'Publish a set of related documents from multiple collections with a reactive join',
-    version: '1.5.2',
+    version: '1.6.0',
     git: 'https://github.com/englue/meteor-publish-composite.git',
 });
 
 Package.onUse((api) => {
-    api.versionsFrom('METEOR@1.4.3');
+    api.versionsFrom('1.6.1');
     api.use([
         'check',
         'ecmascript',


### PR DESCRIPTION
When extracting/loading/building this package on Ubuntu in Meteor 1.6.1 our builds freeze.

Updating the package to use the versionsFrom 1.6.1 fixes this issue.