### PR TITLE
Define children as a function

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,11 @@ Arguments
 
         A function that returns a MongoDB cursor (e.g., `return Meteor.users.find({ active: true });`)
 
-    * **`children`** -- *array (optional)*
+    * **`children`** -- *array (optional)* or *function*
 
-        An array containing any number of object literals with this same structure
+        - An array containing any number of object literals with this same structure
+        - A function with top level documents as arguments. It helps dynamically build
+        the array based on conditions ( like documents fields values)
 
     * **`collectionName`** -- *string (optional)*
 
@@ -85,6 +87,33 @@ Arguments
     }
     ```
 
+    Example with children as function:
+
+    ```javascript
+    {
+      find() {
+          return Notifications.find();
+      },
+      children(parentNotification) {
+        // children is a function that returns an array of objects.
+        // It takes parent documents as arguments and dynamically builds children array.
+        if (parentNotification.type === 'about_post') {
+          return [{
+            find(notification) {
+              return Posts.find(parentNotification.objectId);
+            }
+          }];
+        }
+        return [
+          {
+            find(notification) {
+              return Comments.find(parentNotification.objectId);
+            }
+          }
+        ]
+      }
+    }
+    ```  
 
 ## Examples
 

--- a/lib/publication.js
+++ b/lib/publication.js
@@ -10,7 +10,7 @@ class Publication {
     constructor(subscription, options, args) {
         check(options, {
             find: Function,
-            children: Match.Optional([Object]),
+            children: Match.Optional(Match.OneOf([Object], Function)),
             collectionName: Match.Optional(String),
         });
 
@@ -91,7 +91,9 @@ class Publication {
     }
 
     _publishChildrenOf(doc) {
-        _.each(this.childrenOptions, function createChildPublication(options) {
+        const children = _.isFunction(this.childrenOptions) ?
+        this.childrenOptions(doc, ...this.args) : this.childrenOptions;
+        _.each(children, function createChildPublication(options) {
             const pub = new Publication(this.subscription, options, [doc].concat(this.args));
             this.publishedDocs.addChildPub(doc._id, pub);
             pub.publish();

--- a/tests/client.js
+++ b/tests/client.js
@@ -105,6 +105,21 @@ describe('publishComposite', () => {
         },
     });
 
+    testPublication('Should publish all post comment authors with children as Function', {
+        publication: 'allPostsWithChildrenAsFunction',
+
+        testHandler: (onComplete) => {
+            const comments = Comments.find();
+
+            comments.forEach((comment) => {
+                const commentAuthor = Authors.findOne({ username: comment.author });
+                asyncExpect(() => expect(commentAuthor).to.be.defined, onComplete);
+            });
+
+            onComplete();
+        },
+    });
+
     testPublication('Should publish one user\'s posts', {
         publication: 'userPosts',
         args: ['marie'],
@@ -311,6 +326,20 @@ describe('publishComposite', () => {
 
             asyncExpect(() => expect(albertAsAuthor).to.be.defined, onComplete);
             asyncExpect(() => expect(albertAsCommentAuthor).to.be.defined, onComplete);
+
+            onComplete();
+        },
+    });
+
+    testPublication('Should publish authors to both Authors with children as Function with Multip leLevel', {
+        publication: 'publishCommentAuthorsWithChildrenAsFunctionMultipleLevel',
+
+        testHandler: (onComplete) => {
+            const marieAsAuthor = Authors.findOne({ username: 'marie' });
+            const stephenAsCommentAuthor = CommentAuthors.findOne({ username: 'stephen' });
+
+            asyncExpect(() => expect(marieAsAuthor).to.be.defined, onComplete);
+            asyncExpect(() => expect(stephenAsCommentAuthor).to.not.be.defined, onComplete);
 
             onComplete();
         },

--- a/tests/server.js
+++ b/tests/server.js
@@ -39,6 +39,17 @@ publishComposite('allPosts', {
     children: postPublicationChildren,
 });
 
+publishComposite('allPostsWithChildrenAsFunction', {
+    find() {
+        return Posts.find();
+    },
+    children: parentPost => (parentPost.author === 'albert' ? [{
+        find(post) {
+            return Authors.find({ username: post.author });
+        },
+    }] : postPublicationChildren),
+});
+
 publishComposite('userPosts', username => ({
     find() {
         debugLog('userPosts', 'userPosts.find() called');
@@ -93,6 +104,30 @@ publishComposite('publishCommentAuthorsInAltClientCollection', {
                     },
                 },
             ],
+        },
+    ],
+});
+
+publishComposite('publishCommentAuthorsWithChildrenAsFunctionMultipleLevel', {
+    find() {
+        return Posts.find();
+    },
+    children: [
+        {
+            find(post) {
+                return Authors.find({ username: post.author });
+            },
+        },
+        {
+            find(post) {
+                return Comments.find({ postId: post._id });
+            },
+            children: (parentComment, parentPost) => (parentComment.author === 'richard' ? [{
+                collectionName: 'commentAuthors',
+                find(comment) {
+                    return Authors.find({ username: comment.author });
+                },
+            }] : []),
         },
     ],
 });


### PR DESCRIPTION
The goal is to be able to dynamically build children array based on conditions using parent documents.

Example: **find** returns notifications. Based on type field value, we will publish documents either from **Posts** or **Comments** collections.


```javascript
    {
      find() {
          return Notifications.find();
      },
      children(parentNotification) {
        // children is a function that returns an array of objects.
        // It takes parent documents as arguments and dynamically builds children array.
        if (parentNotification.type === 'about_post') {
          return [{
            find(notification) {
              return Posts.find(parentNotification.objectId);
            }
          }];
        }
        return [
          {
            find(notification) {
              return Comments.find(parentNotification.objectId);
            }
          }
        ]
      }
    }
    ```