### PR TITLE
Handle stopping a publication early

### DIFF
--- a/lib/publication.js
+++ b/lib/publication.js
@@ -20,9 +20,18 @@ class Publication {
         this.childrenOptions = options.children || [];
         this.publishedDocs = new PublishedDocumentList();
         this.collectionName = options.collectionName;
+        this.stopped = false;
+    }
+
+    markAsStopped() {
+        this.stopped = true;
     }
 
     publish() {
+        if (this.stopped) {
+            return;
+        }
+
         this.cursor = this._getCursor();
         if (!this.cursor) { return; }
 
@@ -33,6 +42,10 @@ class Publication {
         // It's only needed when publish is being recursively run.
         this.observeHandle = this.cursor.observe({
             added: Meteor.bindEnvironment((doc) => {
+                if (this.stopped) {
+                    return;
+                }
+
                 const alreadyPublished = this.publishedDocs.has(doc._id);
 
                 if (alreadyPublished) {
@@ -47,10 +60,16 @@ class Publication {
                 }
             }),
             changed: Meteor.bindEnvironment((newDoc) => {
+                if (this.stopped) {
+                    return;
+                }
                 debugLog('Publication.observeHandle.changed', `${collectionName}:${newDoc._id}`);
                 this._republishChildrenOf(newDoc);
             }),
             removed: (doc) => {
+                if (this.stopped) {
+                    return;
+                }
                 debugLog('Publication.observeHandle.removed', `${collectionName}:${doc._id}`);
                 this._removeDoc(collectionName, doc._id);
             },
@@ -58,6 +77,9 @@ class Publication {
 
         this.observeChangesHandle = this.cursor.observeChanges({
             changed: (id, fields) => {
+                if (this.stopped) {
+                    return;
+                }
                 debugLog('Publication.observeChangesHandle.changed', `${collectionName}:${id}`);
                 this.subscription.changed(collectionName, id, fields);
             },

--- a/lib/publication.js
+++ b/lib/publication.js
@@ -20,15 +20,11 @@ class Publication {
         this.childrenOptions = options.children || [];
         this.publishedDocs = new PublishedDocumentList();
         this.collectionName = options.collectionName;
-        this.stopped = false;
-    }
-
-    markAsStopped() {
-        this.stopped = true;
+        this.unpublished = false;
     }
 
     publish() {
-        if (this.stopped) {
+        if (this.unpublished) {
             return;
         }
 
@@ -42,7 +38,7 @@ class Publication {
         // It's only needed when publish is being recursively run.
         this.observeHandle = this.cursor.observe({
             added: Meteor.bindEnvironment((doc) => {
-                if (this.stopped) {
+                if (this.unpublished) {
                     return;
                 }
 
@@ -60,14 +56,14 @@ class Publication {
                 }
             }),
             changed: Meteor.bindEnvironment((newDoc) => {
-                if (this.stopped) {
+                if (this.unpublished) {
                     return;
                 }
                 debugLog('Publication.observeHandle.changed', `${collectionName}:${newDoc._id}`);
                 this._republishChildrenOf(newDoc);
             }),
             removed: (doc) => {
-                if (this.stopped) {
+                if (this.unpublished) {
                     return;
                 }
                 debugLog('Publication.observeHandle.removed', `${collectionName}:${doc._id}`);
@@ -77,7 +73,7 @@ class Publication {
 
         this.observeChangesHandle = this.cursor.observeChanges({
             changed: (id, fields) => {
-                if (this.stopped) {
+                if (this.unpublished) {
                     return;
                 }
                 debugLog('Publication.observeChangesHandle.changed', `${collectionName}:${id}`);
@@ -88,6 +84,7 @@ class Publication {
 
     unpublish() {
         debugLog('Publication.unpublish', this._getCollectionName());
+        this.unpublished = true;
         this._stopObservingCursor();
         this._unpublishAllDocuments();
     }

--- a/lib/publish_composite.js
+++ b/lib/publish_composite.js
@@ -27,7 +27,6 @@ function publishComposite(name, options) {
 
         this.onStop(() => {
             publications.forEach(pub => {
-                pub.markAsStopped();
                 pub.unpublish();
             });
         });

--- a/lib/publish_composite.js
+++ b/lib/publish_composite.js
@@ -26,9 +26,7 @@ function publishComposite(name, options) {
         });
 
         this.onStop(() => {
-            publications.forEach(pub => {
-                pub.unpublish();
-            });
+            publications.forEach(pub => pub.unpublish());
         });
     });
 }

--- a/lib/publish_composite.js
+++ b/lib/publish_composite.js
@@ -14,16 +14,23 @@ function publishComposite(name, options) {
 
         instanceOptions.forEach((opt) => {
             const pub = new Publication(subscription, opt);
-            pub.publish();
             publications.push(pub);
         });
 
-        this.onStop(() => {
-            publications.forEach(pub => pub.unpublish());
+        Meteor.defer(() => {
+            publications.forEach((pub) => {
+                pub.publish();
+            });
+            debugLog('Meteor.publish', 'ready');
+            this.ready();
         });
 
-        debugLog('Meteor.publish', 'ready');
-        this.ready();
+        this.onStop(() => {
+            publications.forEach(pub => {
+                pub.markAsStopped();
+                pub.unpublish();
+            });
+        });
     });
 }
 


### PR DESCRIPTION
I've encountered a situation where if you subscribe to a huge publication, or any-sized publication really, and you want to stop it early, the publication won't stop until all the cursors have finished running (i.e. [`onStop`](https://github.com/englue/meteor-publish-composite/blob/ee4ae61571b9195ad9480c38c06f40c8a988e118/lib/publish_composite.js#L22) doesn't get called until the cursors have returned). This PR allows the `onStop` to be called immediately in order to stop the cursors. This PR potentially fixes other issues people are having that they may have perceived as a performance issue.

The code on `publication.js` isn't so great but it works. I am open for someone to clean that up so it isn't so terrible.